### PR TITLE
Extract filepaths -> label rules from code into external .yml config

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,152 @@
+## Order of entries in this map *does* matter for the resolved labels
+## earlier entries override later entries
+subSystemLabels:
+  # src subsystems
+  /^src\/async-wrap/: c++, async_wrap
+  /^src\/(?:base64|node_buffer|string_)/: c++, buffer
+  /^src\/cares/: c++, cares
+  /^src\/(?:process_wrap|spawn_)/: c++, child_process
+  /^src\/(?:node_)?crypto/: c++, crypto
+  /^src\/(?:debug-|node_debug)/: c++, debugger
+  /^src\/udp_/: c++, dgram
+  /^src\/(?:fs_|node_file|node_stat_watcher)/: c++, fs
+  /^src\/node_http_parser/: c++, http_parser
+  /^src\/node_i18n/: c++, intl
+  /^src\/uv\./: c++, libuv
+  /^src\/(?:connect(?:ion)?|pipe|tcp)_/: c++, net
+  /^src\/node_os/: c++, os
+  /^src\/(?:node_main|signal_)/: c++, process
+  /^src\/timer_/: c++, timers
+  /^src\/(?:CNNICHashWhitelist|node_root_certs|tls_)/: c++, tls
+  /^src\/tty_/: c++, tty
+  /^src\/node_url/: c++, url-whatwg
+  /^src\/node_util/: c++, util
+  /^src\/(?:node_v8|v8abbr)/: c++, V8 Engine
+  /^src\/node_contextify/: c++, vm
+  /^src\/.*win32.*/: c++, windows
+  /^src\/node_zlib/: c++, zlib
+  /^src\/tracing/: c++, tracing
+  /^src\/node_api/: c++, n-api
+  /^src\/node_http2/: c++, http2, dont-land-on-v6.x
+  /^src\/node_report/: c++, report
+  /^src\/node_wasi/: c++, wasi
+  /^src\/node_worker/: c++, worker
+  /^src\/quic\/*/: c++, quic, dont-land-on-v14.x, dont-land-on-v12.x
+  /^src\/node_bob*/: c++, quic, dont-land-on-v14.x, dont-land-on-v12.x
+
+  # don't label python files as c++
+  /^src\/.+\.py$/: lib / src
+
+  # properly label changes to v8 inspector integration-related files
+  /^src\/inspector_/: c++, inspector
+
+  # don't want to label it a c++ update when we're "only" bumping the Node.js version
+  /^src\/(?!node_version\.h)/: c++
+  # BUILDING.md should be marked as 'build' in addition to 'doc'
+  /^BUILDING\.md$/: build, doc
+  # meta is a very specific label for things that are policy and or meta-info related
+  /^([A-Z]+$|CODE_OF_CONDUCT|ROADMAP|WORKING_GROUPS|GOVERNANCE|CHANGELOG|\.mail|\.git.+)/: meta
+  # things that edit top-level .md files are always a doc change
+  /^\w+\.md$/: doc
+  # different variants of *Makefile and build files
+  /^(tools\/)?(Makefile|BSDmakefile|create_android_makefiles|\.travis\.yml)$/: build
+  /^tools\/(install\.py|genv8constants\.py|getnodeversion\.py|js2c\.py|utils\.py|configure\.d\/.*)$/: build
+  /^vcbuild\.bat$/: build, windows
+  /^(android-)?configure|node\.gyp|common\.gypi$/: build
+  # more specific tools
+  /^tools\/gyp/: tools, build
+  /^tools\/doc\//: tools, doc
+  /^tools\/icu\//: tools, intl
+  /^tools\/(?:osx-pkg\.pmdoc|pkgsrc)\//: tools, macos, install
+  /^tools\/(?:(?:mac)?osx-)/: tools, macos
+  /^tools\/test-npm/: tools, test, npm
+  /^tools\/test/: tools, test
+  /^tools\/(?:certdata|mkssldef|mk-ca-bundle)/: tools, openssl, tls
+  /^tools\/msvs\//: tools, windows, install
+  /^tools\/[^/]+\.bat$/: tools, windows
+  /^tools\/make-v8/: tools, V8 Engine
+  # all other tool changes should be marked as such
+  /^tools\//: tools
+  /^\.eslint|\.remark|\.editorconfig/: tools
+
+  ## Dependencies
+  # libuv needs an explicit mapping, as the ordinary /deps/ mapping below would
+  # end up as libuv changes labeled with "uv" (which is a non-existing label)
+  /^deps\/uv\//: libuv
+  /^deps\/v8\/tools\/gen-postmortem-metadata\.py/: V8 Engine, post-mortem
+  /^deps\/v8\//: V8 Engine
+  /^deps\/uvwasi\//: wasi
+  /^deps\/nghttp2\/nghttp2\.gyp/: build, http2, dont-land-on-v6.x
+  /^deps\/nghttp2\//: http2, dont-land-on-v6.x
+  /^deps\/ngtcp2\//: quic, dont-land-on-v14.x, dont-land-on-v12.x
+  /^deps\/nghttp3\//: quic, dont-land-on-v14.x, dont-land-on-v12.x
+  /^deps\/([^/]+)/: $1
+
+  ## JS subsystems
+  # Oddities first
+  /^lib\/(punycode|\w+\/freelist|sys\.js)/: ''
+  /^lib\/constants\.js$/: lib / src
+  /^lib\/_(debug_agent|debugger)\.js$/: debugger
+  /^lib(\/\w+)?\/(_)?link(ed)?list/: timers
+  /^lib\/\w+\/bootstrap_node/: lib / src
+  /^lib\/\w+\/v8_prof_/: tools
+  /^lib\/\w+\/socket_list/: net
+  /^lib\/\w+\/streams$/: stream
+  /^lib\/.*http2/: http2, dont-land-on-v6.x
+  /^lib\/worker_threads.js$/: worker
+  /^lib\/internal\/url\.js$/: url-whatwg
+  /^lib\/internal\/modules\/esm/: ES Modules
+  /^lib\/internal\/quic\/*/: quic, dont-land-on-v14.x, dont-land-on-v12.x
+
+  # All other lib/ files map directly
+  /^lib\/_(\w+)_\w+\.js?$/: $1 # e.g. _(stream)_wrap
+  /^lib(\/internal)?\/(\w+)\.js?$/: $2 # other .js files
+  /^lib\/internal\/(\w+)(?:\/|$)/: $1 # internal subfolders
+
+exlusiveLabels:
+  # more specific tests
+  /^test\/addons\//: test, addons
+  /^test\/debugger\//: test, debugger
+  /^test\/doctool\//: test, doc, tools
+  /^test\/timers\//: test, timers
+  /^test\/pseudo-tty\//: test, tty
+  /^test\/inspector\//: test, inspector
+  /^test\/cctest\/test_inspector/: test, inspector
+  /^test\/cctest\/test_url/: test, url-whatwg
+  /^test\/addons-napi\//: test, n-api
+  /^test\/async-hooks\//: test, async_hooks
+  /^test\/report\//: test, report
+  /^test\/fixtures\/es-module/: test, ES Modules
+  /^test\/es-module\//: test, ES Modules
+
+  /^test\//: test
+
+    # specific map for webcrypto.md as it should be labeled 'crypto'
+  /^doc\/api\/webcrypto.md$/: doc, crypto
+    # specific map for modules.md as it should be labeled 'module' not 'modules'
+  /^doc\/api\/modules.md$/: doc, module
+    # specific map for esm.md as it should be labeled 'ES Modules' not 'esm'
+  /^doc\/api\/esm.md$/: doc, ES Modules
+    # n-api is treated separately since it is not a JS core module but is still
+    # considered a subsystem of sorts
+  /^doc\/api\/n-api.md$/: doc, n-api
+    # quic
+  /^doc\/api\/quic.md$/: doc, quic, dont-land-on-v14.x, dont-land-on-v12.x
+    # add worker label to PRs that affect doc/api/worker_threads.md
+  /^doc\/api\/worker_threads.md$/: doc, worker
+    # automatically tag JS subsystem-specific API doc changes
+  /^doc\/api\/(\w+)\.md$/: doc, $1
+    # add deprecations label to PRs that affect doc/api/deprecations.md
+  /^doc\/api\/deprecations.md$/: doc, deprecations
+
+  /^doc\//: doc
+
+    # more specific benchmarks
+  /^benchmark\/buffers\//: benchmark, buffer
+  /^benchmark\/(?:arrays|es)\//: benchmark, V8 Engine
+  /^benchmark\/_http/: benchmark, http
+  /^benchmark\/(?:misc|fixtures)\//: benchmark
+  /^benchmark\/streams\//: benchmark, stream
+  /^benchmark\/([^/]+)\//: benchmark, $1
+
+  /^benchmark\//: benchmark

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -150,3 +150,44 @@ exlusiveLabels:
   /^benchmark\/([^/]+)\//: benchmark, $1
 
   /^benchmark\//: benchmark
+
+allJsSubSystems:
+  - assert
+  - async_hooks
+  - buffer
+  - child_process
+  - cluster
+  - console
+  - crypto
+  - debugger
+  - dgram
+  - dns
+  - domain
+  - events
+  - esm
+  - fs
+  - http
+  - https
+  - http2
+  - module
+  - net
+  - os
+  - path
+  - process
+  - querystring
+  - quic
+  - readline
+  - repl
+  - report
+  - stream
+  - string_decoder
+  - timers
+  - tls
+  - tty
+  - url
+  - util
+  - v8
+  - vm
+  - wasi
+  - worker
+  - zlib

--- a/lib/resolve-labels.js
+++ b/lib/resolve-labels.js
@@ -1,109 +1,25 @@
 'use strict'
 
+const yaml = require('js-yaml')
+const fs = require('fs')
+const path = require('path')
+
+// TODO: make configurable
+const config = yaml.load(fs.readFileSync(path.join(__dirname, '../.github/pr-labeler.yml'), 'utf8'))
+
+function parseRegexToLabelsConfig (objectFromYaml) {
+  return Object.entries(objectFromYaml)
+    .map(([regexAsString, labelsAsString]) => {
+      const withoutWrappingSlashes = regexAsString.substr(1, regexAsString.length - 2)
+      const labels = labelsAsString.split(',').map(label => label.trim())
+
+      return [new RegExp(withoutWrappingSlashes), labels]
+    })
+}
+
 // order of entries in this map *does* matter for the resolved labels
 // earlier entries override later entries
-const subSystemLabelsMap = new Map([
-  /* src subsystems */
-  [/^src\/async-wrap/, ['c++', 'async_wrap']],
-  [/^src\/(?:base64|node_buffer|string_)/, ['c++', 'buffer']],
-  [/^src\/cares/, ['c++', 'cares']],
-  [/^src\/(?:process_wrap|spawn_)/, ['c++', 'child_process']],
-  [/^src\/(?:node_)?crypto/, ['c++', 'crypto']],
-  [/^src\/(?:debug-|node_debug)/, ['c++', 'debugger']],
-  [/^src\/udp_/, ['c++', 'dgram']],
-  [/^src\/(?:fs_|node_file|node_stat_watcher)/, ['c++', 'fs']],
-  [/^src\/node_http_parser/, ['c++', 'http_parser']],
-  [/^src\/node_i18n/, ['c++', 'intl']],
-  [/^src\/uv\./, ['c++', 'libuv']],
-  [/^src\/(?:connect(?:ion)?|pipe|tcp)_/, ['c++', 'net']],
-  [/^src\/node_os/, ['c++', 'os']],
-  [/^src\/(?:node_main|signal_)/, ['c++', 'process']],
-  [/^src\/timer_/, ['c++', 'timers']],
-  [/^src\/(?:CNNICHashWhitelist|node_root_certs|tls_)/, ['c++', 'tls']],
-  [/^src\/tty_/, ['c++', 'tty']],
-  [/^src\/node_url/, ['c++', 'url-whatwg']],
-  [/^src\/node_util/, ['c++', 'util']],
-  [/^src\/(?:node_v8|v8abbr)/, ['c++', 'V8 Engine']],
-  [/^src\/node_contextify/, ['c++', 'vm']],
-  [/^src\/.*win32.*/, ['c++', 'windows']],
-  [/^src\/node_zlib/, ['c++', 'zlib']],
-  [/^src\/tracing/, ['c++', 'tracing']],
-  [/^src\/node_api/, ['c++', 'n-api']],
-  [/^src\/node_http2/, ['c++', 'http2', 'dont-land-on-v6.x']],
-  [/^src\/node_report/, ['c++', 'report']],
-  [/^src\/node_wasi/, ['c++', 'wasi']],
-  [/^src\/node_worker/, ['c++', 'worker']],
-  [/^src\/quic\/*/, ['c++', 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x']],
-  [/^src\/node_bob*/, ['c++', 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x']],
-
-  // don't label python files as c++
-  [/^src\/.+\.py$/, 'lib / src'],
-
-  // properly label changes to v8 inspector integration-related files
-  [/^src\/inspector_/, ['c++', 'inspector']],
-
-  // don't want to label it a c++ update when we're "only" bumping the Node.js version
-  [/^src\/(?!node_version\.h)/, 'c++'],
-  // BUILDING.md should be marked as 'build' in addition to 'doc'
-  [/^BUILDING\.md$/, ['build', 'doc']],
-  // meta is a very specific label for things that are policy and or meta-info related
-  [/^([A-Z]+$|CODE_OF_CONDUCT|ROADMAP|WORKING_GROUPS|GOVERNANCE|CHANGELOG|\.mail|\.git.+)/, 'meta'],
-  // things that edit top-level .md files are always a doc change
-  [/^\w+\.md$/, 'doc'],
-  // different variants of *Makefile and build files
-  [/^(tools\/)?(Makefile|BSDmakefile|create_android_makefiles|\.travis\.yml)$/, 'build'],
-  [/^tools\/(install\.py|genv8constants\.py|getnodeversion\.py|js2c\.py|utils\.py|configure\.d\/.*)$/, 'build'],
-  [/^vcbuild\.bat$/, ['build', 'windows']],
-  [/^(android-)?configure|node\.gyp|common\.gypi$/, 'build'],
-  // more specific tools
-  [/^tools\/gyp/, ['tools', 'build']],
-  [/^tools\/doc\//, ['tools', 'doc']],
-  [/^tools\/icu\//, ['tools', 'intl']],
-  [/^tools\/(?:osx-pkg\.pmdoc|pkgsrc)\//, ['tools', 'macos', 'install']],
-  [/^tools\/(?:(?:mac)?osx-)/, ['tools', 'macos']],
-  [/^tools\/test-npm/, ['tools', 'test', 'npm']],
-  [/^tools\/test/, ['tools', 'test']],
-  [/^tools\/(?:certdata|mkssldef|mk-ca-bundle)/, ['tools', 'openssl', 'tls']],
-  [/^tools\/msvs\//, ['tools', 'windows', 'install']],
-  [/^tools\/[^/]+\.bat$/, ['tools', 'windows']],
-  [/^tools\/make-v8/, ['tools', 'V8 Engine']],
-  // all other tool changes should be marked as such
-  [/^tools\//, 'tools'],
-  [/^\.eslint|\.remark|\.editorconfig/, 'tools'],
-
-  /* Dependencies */
-  // libuv needs an explicit mapping, as the ordinary /deps/ mapping below would
-  // end up as libuv changes labeled with "uv" (which is a non-existing label)
-  [/^deps\/uv\//, 'libuv'],
-  [/^deps\/v8\/tools\/gen-postmortem-metadata\.py/, ['V8 Engine', 'post-mortem']],
-  [/^deps\/v8\//, 'V8 Engine'],
-  [/^deps\/uvwasi\//, 'wasi'],
-  [/^deps\/nghttp2\/nghttp2\.gyp/, ['build', 'http2', 'dont-land-on-v6.x']],
-  [/^deps\/nghttp2\//, ['http2', 'dont-land-on-v6.x']],
-  [/^deps\/ngtcp2\//, 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x'],
-  [/^deps\/nghttp3\//, 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x'],
-  [/^deps\/([^/]+)/, '$1'],
-
-  /* JS subsystems */
-  // Oddities first
-  [/^lib\/(punycode|\w+\/freelist|sys\.js)/, ''], // TODO: ignore better?
-  [/^lib\/constants\.js$/, 'lib / src'],
-  [/^lib\/_(debug_agent|debugger)\.js$/, 'debugger'],
-  [/^lib(\/\w+)?\/(_)?link(ed)?list/, 'timers'],
-  [/^lib\/\w+\/bootstrap_node/, 'lib / src'],
-  [/^lib\/\w+\/v8_prof_/, 'tools'],
-  [/^lib\/\w+\/socket_list/, 'net'],
-  [/^lib\/\w+\/streams$/, 'stream'],
-  [/^lib\/.*http2/, ['http2', 'dont-land-on-v6.x']],
-  [/^lib\/worker_threads.js$/, ['worker']],
-  [/^lib\/internal\/url\.js$/, ['url-whatwg']],
-  [/^lib\/internal\/modules\/esm/, 'ES Modules'],
-  [/^lib\/internal\/quic\/*/, ['quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x']],
-  // All other lib/ files map directly
-  [/^lib\/_(\w+)_\w+\.js?$/, '$1'], // e.g. _(stream)_wrap
-  [/^lib(\/internal)?\/(\w+)\.js?$/, '$2'], // other .js files
-  [/^lib\/internal\/(\w+)(?:\/|$)/, '$1'] // internal subfolders
-])
+const subSystemLabelsMap = new Map(parseRegexToLabelsConfig(config.subSystemLabels))
 
 const jsSubsystemList = [
   'debugger', 'assert', 'async_hooks', 'buffer', 'child_process', 'cluster',
@@ -113,54 +29,7 @@ const jsSubsystemList = [
   'tls', 'tty', 'url', 'util', 'v8', 'vm', 'wasi', 'worker', 'zlib'
 ]
 
-const exclusiveLabelsMap = new Map([
-  // more specific tests
-  [/^test\/addons\//, ['test', 'addons']],
-  [/^test\/debugger\//, ['test', 'debugger']],
-  [/^test\/doctool\//, ['test', 'doc', 'tools']],
-  [/^test\/timers\//, ['test', 'timers']],
-  [/^test\/pseudo-tty\//, ['test', 'tty']],
-  [/^test\/inspector\//, ['test', 'inspector']],
-  [/^test\/cctest\/test_inspector/, ['test', 'inspector']],
-  [/^test\/cctest\/test_url/, ['test', 'url-whatwg']],
-  [/^test\/addons-napi\//, ['test', 'n-api']],
-  [/^test\/async-hooks\//, ['test', 'async_hooks']],
-  [/^test\/report\//, ['test', 'report']],
-  [/^test\/fixtures\/es-module/, ['test', 'ES Modules']],
-  [/^test\/es-module\//, ['test', 'ES Modules']],
-
-  [/^test\//, 'test'],
-
-  // specific map for webcrypto.md as it should be labeled 'crypto'
-  [/^doc\/api\/webcrypto.md$/, ['doc', 'crypto']],
-  // specific map for modules.md as it should be labeled 'module' not 'modules'
-  [/^doc\/api\/modules.md$/, ['doc', 'module']],
-  // specific map for esm.md as it should be labeled 'ES Modules' not 'esm'
-  [/^doc\/api\/esm.md$/, ['doc', 'ES Modules']],
-  // n-api is treated separately since it is not a JS core module but is still
-  // considered a subsystem of sorts
-  [/^doc\/api\/n-api.md$/, ['doc', 'n-api']],
-  // quic
-  [/^doc\/api\/quic.md$/, ['doc', 'quic', 'dont-land-on-v14.x', 'dont-land-on-v12.x']],
-  // add worker label to PRs that affect doc/api/worker_threads.md
-  [/^doc\/api\/worker_threads.md$/, ['doc', 'worker']],
-  // automatically tag JS subsystem-specific API doc changes
-  [/^doc\/api\/(\w+)\.md$/, ['doc', '$1']],
-  // add deprecations label to PRs that affect doc/api/deprecations.md
-  [/^doc\/api\/deprecations.md$/, ['doc', 'deprecations']],
-
-  [/^doc\//, 'doc'],
-
-  // more specific benchmarks
-  [/^benchmark\/buffers\//, ['benchmark', 'buffer']],
-  [/^benchmark\/(?:arrays|es)\//, ['benchmark', 'V8 Engine']],
-  [/^benchmark\/_http/, ['benchmark', 'http']],
-  [/^benchmark\/(?:misc|fixtures)\//, 'benchmark'],
-  [/^benchmark\/streams\//, ['benchmark', 'stream']],
-  [/^benchmark\/([^/]+)\//, ['benchmark', '$1']],
-
-  [/^benchmark\//, 'benchmark']
-])
+const exclusiveLabelsMap = new Map(parseRegexToLabelsConfig(config.exlusiveLabels))
 
 function resolveLabels (filepathsChanged, baseBranch, limitLabels = true) {
   const exclusiveLabels = matchExclusiveSubSystem(filepathsChanged)
@@ -276,7 +145,7 @@ function hasLibOrSrcChanges (filepathsChanged) {
 }
 
 function mappedSubSystemsForFile (labelsMap, filepath) {
-  for (const [regex, label] of labelsMap) {
+  for (const [regex, labels] of labelsMap) {
     const matches = regex.exec(filepath)
 
     if (matches === null) {
@@ -284,7 +153,6 @@ function mappedSubSystemsForFile (labelsMap, filepath) {
     }
 
     const ret = []
-    const labels = Array.isArray(label) ? label : [label]
     labels.forEach((label) => {
       // label names starting with $ means we want to extract a matching
       // group from the regex we've just matched against

--- a/lib/resolve-labels.js
+++ b/lib/resolve-labels.js
@@ -17,19 +17,9 @@ function parseRegexToLabelsConfig (objectFromYaml) {
     })
 }
 
-// order of entries in this map *does* matter for the resolved labels
-// earlier entries override later entries
 const subSystemLabelsMap = new Map(parseRegexToLabelsConfig(config.subSystemLabels))
-
-const jsSubsystemList = [
-  'debugger', 'assert', 'async_hooks', 'buffer', 'child_process', 'cluster',
-  'console', 'crypto', 'dgram', 'dns', 'domain', 'events', 'esm', 'fs', 'http',
-  'https', 'http2', 'module', 'net', 'os', 'path', 'process', 'querystring',
-  'quic', 'readline', 'repl', 'report', 'stream', 'string_decoder', 'timers',
-  'tls', 'tty', 'url', 'util', 'v8', 'vm', 'wasi', 'worker', 'zlib'
-]
-
 const exclusiveLabelsMap = new Map(parseRegexToLabelsConfig(config.exlusiveLabels))
+const jsSubsystemList = config.allJsSubSystems
 
 function resolveLabels (filepathsChanged, baseBranch, limitLabels = true) {
   const exclusiveLabels = matchExclusiveSubSystem(filepathsChanged)

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,6 +184,27 @@
         "lodash": "^4.17.19",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "@octokit/auth-token": {
@@ -387,13 +408,9 @@
       "dev": true
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "array-includes": {
       "version": "3.1.3",
@@ -788,6 +805,27 @@
         "log-driver": "^1.2.7",
         "minimist": "^1.2.5",
         "request": "^2.88.2"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "cp-file": {
@@ -1024,6 +1062,27 @@
         "table": "^5.2.3",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "eslint-config-standard": {
@@ -2072,13 +2131,11 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "jsbn": {
@@ -2442,6 +2499,15 @@
         "yargs-parser": "^13.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -2449,6 +2515,16 @@
           "dev": true,
           "requires": {
             "locate-path": "^3.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "locate-path": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@actions/core": "^1.2.6",
     "@actions/github": "^4.0.0",
-    "aigle": "^1.14.1"
+    "aigle": "^1.14.1",
+    "js-yaml": "^4.0.0"
   }
 }


### PR DESCRIPTION
This is the first successful step in moving the mapping/rules between filepaths and label names, from the .js source code into an external .yml configuration file.

At the moment, the .yml location is hard coded to just make the test suite pass as before.

That won't be of much help in the long run, as GitHub repos will want to configure the .yml location themselves, and of course for them to have that file in their own repository.

**Next step;** make the .yml path configurable and download the configuration file contents from the target repo, where this GitHub Action is destined to run.