### PR TITLE
Provide external configuration file contents when resolving labels

### DIFF
--- a/lib/resolve-labels.js
+++ b/lib/resolve-labels.js
@@ -1,11 +1,6 @@
 'use strict'
 
 const yaml = require('js-yaml')
-const fs = require('fs')
-const path = require('path')
-
-// TODO: make configurable
-const config = yaml.load(fs.readFileSync(path.join(__dirname, '../.github/pr-labeler.yml'), 'utf8'))
 
 function parseRegexToLabelsConfig (objectFromYaml) {
   return Object.entries(objectFromYaml)
@@ -17,15 +12,16 @@ function parseRegexToLabelsConfig (objectFromYaml) {
     })
 }
 
-const subSystemLabelsMap = new Map(parseRegexToLabelsConfig(config.subSystemLabels))
-const exclusiveLabelsMap = new Map(parseRegexToLabelsConfig(config.exlusiveLabels))
-const jsSubsystemList = config.allJsSubSystems
+function resolveLabels (filepathsChanged, baseBranch, configAsString) {
+  const config = yaml.load(configAsString)
+  const exclusiveLabelsMap = new Map(parseRegexToLabelsConfig(config.exlusiveLabels))
+  const subSystemLabelsMap = new Map(parseRegexToLabelsConfig(config.subSystemLabels))
+  const allJsSubSystems = config.allJsSubSystems
 
-function resolveLabels (filepathsChanged, baseBranch) {
-  const exclusiveLabels = matchExclusiveSubSystem(filepathsChanged)
+  const exclusiveLabels = matchExclusiveSubSystem(filepathsChanged, exclusiveLabelsMap, allJsSubSystems)
   const labels = (exclusiveLabels.length > 0)
     ? exclusiveLabels
-    : matchAllSubSystem(filepathsChanged)
+    : matchAllSubSystem(filepathsChanged, subSystemLabelsMap)
 
   // Add version labels if PR is made against a version branch
   const m = /^(v\d+\.(?:\d+|x))(?:-staging|$)/.exec(baseBranch)
@@ -36,10 +32,8 @@ function resolveLabels (filepathsChanged, baseBranch) {
   return labels
 }
 
-function hasAllSubsystems (arr) {
-  return arr.every((val) => {
-    return jsSubsystemList.includes(val)
-  })
+function hasAllSubsystems (labels, allJsSubSystems) {
+  return labels.every((label) => allJsSubSystems.includes(label))
 }
 
 // This function is needed to help properly identify when a PR should always
@@ -57,8 +51,8 @@ function hasAllTestChanges (arr) {
   })
 }
 
-function matchExclusiveSubSystem (filepathsChanged) {
-  const isExclusive = filepathsChanged.every(matchesAnExclusiveLabel)
+function matchExclusiveSubSystem (filepathsChanged, exclusiveLabelsMap, allJsSubSystems) {
+  const isExclusive = filepathsChanged.every(matchesAnExclusiveLabel, exclusiveLabelsMap)
   let labels = matchSubSystemsByRegex(exclusiveLabelsMap, filepathsChanged)
   const nonMetaLabels = labels.filter((label) => {
     return !/^dont-/.test(label)
@@ -72,7 +66,7 @@ function matchExclusiveSubSystem (filepathsChanged) {
     const nonDocLabels = nonMetaLabels.filter((val) => {
       return val !== 'doc'
     })
-    if (hasAllSubsystems(nonDocLabels) || hasAllDocChanges(filepathsChanged)) {
+    if (hasAllSubsystems(nonDocLabels, allJsSubSystems) || hasAllDocChanges(filepathsChanged)) {
       labels = ['doc']
     } else {
       labels = []
@@ -81,7 +75,7 @@ function matchExclusiveSubSystem (filepathsChanged) {
   return isExclusive ? labels : []
 }
 
-function matchAllSubSystem (filepathsChanged) {
+function matchAllSubSystem (filepathsChanged, subSystemLabelsMap) {
   return matchSubSystemsByRegex(
     subSystemLabelsMap, filepathsChanged)
 }
@@ -153,7 +147,7 @@ function mappedSubSystemsForFile (labelsMap, filepath) {
 }
 
 function matchesAnExclusiveLabel (filepath) {
-  return mappedSubSystemsForFile(exclusiveLabelsMap, filepath) !== undefined
+  return mappedSubSystemsForFile(this, filepath) !== undefined
 }
 
 module.exports = resolveLabels

--- a/test/resolve-labels.test.js
+++ b/test/resolve-labels.test.js
@@ -1,8 +1,14 @@
 'use strict'
 
+const fs = require('fs')
+const path = require('path')
 const tap = require('tap')
 
-const resolveLabels = require('../lib/resolve-labels')
+const actualResolveLabels = require('../lib/resolve-labels')
+
+const config = fs.readFileSync(path.join(__dirname, '../.github/pr-labeler.yml'), 'utf8')
+const defaultBaseBranch = 'master'
+const resolveLabels = (filepathsChanged, baseBranch) => actualResolveLabels(filepathsChanged, baseBranch || defaultBaseBranch, config)
 
 tap.test('no labels: when ./test/ and ./doc/ files has been changed', (t) => {
   const labels = resolveLabels([


### PR DESCRIPTION
These changes makes our resolve labels logic unaware of *where* the configuration / label rules comes from. As long as the .yml contents is provided to `.resolveLabels()` as a `string`, it's all fine and dandy.

This is exactly what we'll need around the corner when truly making this a GitHub Action, where it's planned to fetch this configuration from the target repo somewhere..